### PR TITLE
Fix unhandled enum unit variant/string case

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -109,6 +109,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
 
                 (variant, Some(value))
             }
+            Key::String(_) => (self.value, None),
             _ => {
                 return Err(Error::Unexpected("string or map"));
             }

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -40,12 +40,17 @@ fn test_enum() -> Result<(), Error> {
     }
 
     assert_eq!(foo, from_key::<Foo>(&value)?);
+    assert_eq!(
+        Foo::Operation3,
+        from_key::<Foo>(&to_key(&Foo::Operation3)?)?
+    );
     return Ok(());
 
     #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
     enum Foo {
         Operation1(String, String),
         Operation2(String),
+        Operation3,
     }
 }
 


### PR DESCRIPTION
Cheers! This fixes an issue where enum unit variants like `Foo::Bar` would get serialized just fine but the deserializer missed the case where a variant might be just a string key (not a JSON-style map.) Adds a test to verify it, too. Please take a look! :)