### PR TITLE
Support f32/f64 through the ordered-float crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.98" }
+ordered-float = "2.0.0"
 
 [dev-dependencies]
 serde_derive = { version = "1.0.98" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.98" }
+serde_derive = { version = "1.0.98" }
 ordered-float = "2.0.0"
 
 [dev-dependencies]
-serde_derive = { version = "1.0.98" }
 serde_json = "1.0.40"

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,12 +1,12 @@
 //! Deserialization for serde-hashkey.
 
-use ordered_float::OrderedFloat;
 use serde::de::{self, IntoDeserializer};
 use std::fmt;
+use std::marker::PhantomData;
 
 use crate::{
     error::Error,
-    key::{Float, Integer, Key},
+    key::{FloatPolicy, FloatProxy, Integer, Key},
 };
 
 /// Deserialize the given type from a [Key].
@@ -53,25 +53,71 @@ where
     T::deserialize(Deserializer::new(&value))
 }
 
-impl<'de> IntoDeserializer<'de, Error> for &'de Key {
-    type Deserializer = Deserializer<'de>;
+/// Deserialize the given type from a [Key], with a non-default [`FloatPolicy`](key::FloatPolicy).
+///
+/// # Examples
+///
+/// ```rust
+/// use serde_derive::{Deserialize, Serialize};
+/// use serde_hashkey::{from_key_with_policy, to_key_with_policy, OrderedFloat, Key};
+/// use std::collections::HashMap;
+///
+/// #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// struct Author {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// struct Book {
+///     title: String,
+///     author: Author,
+/// }
+///
+/// # fn main() -> serde_hashkey::Result<()> {
+/// let book = Book {
+///     title: String::from("Birds of a feather"),
+///     author: Author {
+///         name: String::from("Noah"),
+///         age: 42,
+///     },
+/// };
+///
+/// let key = to_key_with_policy::<OrderedFloat, _>(&book)?;
+/// let book2 = from_key_with_policy::<OrderedFloat, _>(&key)?;
+///
+/// assert_eq!(book, book2);
+/// # Ok(())
+/// # }
+/// ```
+pub fn from_key_with_policy<Float: FloatPolicy, T>(
+    value: &Key<Float>,
+) -> Result<T, crate::error::Error>
+where
+    T: de::DeserializeOwned,
+{
+    T::deserialize(Deserializer::new(&value))
+}
+
+impl<'de, Float: FloatPolicy> IntoDeserializer<'de, Error> for &'de Key<Float> {
+    type Deserializer = Deserializer<'de, Float>;
 
     fn into_deserializer(self) -> Self::Deserializer {
         Deserializer::new(self)
     }
 }
 
-pub struct Deserializer<'de> {
-    value: &'de Key,
+pub struct Deserializer<'de, Float: FloatPolicy> {
+    value: &'de Key<Float>,
 }
 
-impl<'de> Deserializer<'de> {
-    pub fn new(value: &'de Key) -> Self {
+impl<'de, Float: FloatPolicy> Deserializer<'de, Float> {
+    pub fn new(value: &'de Key<Float>) -> Self {
         Self { value }
     }
 }
 
-impl<'de> de::Deserializer<'de> for Deserializer<'de> {
+impl<'de, Float: FloatPolicy> de::Deserializer<'de> for Deserializer<'de, Float> {
     type Error = Error;
 
     #[inline]
@@ -92,8 +138,10 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
             Key::Integer(Integer::I32(v)) => visitor.visit_i32(*v),
             Key::Integer(Integer::I64(v)) => visitor.visit_i64(*v),
             Key::Integer(Integer::I128(v)) => visitor.visit_i128(*v),
-            Key::Float(Float::F32(OrderedFloat(v))) => visitor.visit_f32(*v),
-            Key::Float(Float::F64(OrderedFloat(v))) => visitor.visit_f64(*v),
+            Key::Float(float) => match float.clone().into() {
+                FloatProxy::F32(v) => visitor.visit_f32(v),
+                FloatProxy::F64(v) => visitor.visit_f64(v),
+            },
             Key::String(s) => visitor.visit_str(s),
             Key::Vec(array) => visitor.visit_seq(SeqDeserializer::new(array)),
             Key::Map(m) => visitor.visit_map(MapDeserializer::new(m)),
@@ -169,14 +217,14 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
     }
 }
 
-struct EnumDeserializer<'de> {
-    variant: &'de Key,
-    value: Option<&'de Key>,
+struct EnumDeserializer<'de, Float: FloatPolicy> {
+    variant: &'de Key<Float>,
+    value: Option<&'de Key<Float>>,
 }
 
-impl<'de> de::EnumAccess<'de> for EnumDeserializer<'de> {
+impl<'de, Float: FloatPolicy> de::EnumAccess<'de> for EnumDeserializer<'de, Float> {
     type Error = Error;
-    type Variant = VariantDeserializer<'de>;
+    type Variant = VariantDeserializer<'de, Float>;
 
     fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Error>
     where
@@ -188,11 +236,11 @@ impl<'de> de::EnumAccess<'de> for EnumDeserializer<'de> {
     }
 }
 
-struct VariantDeserializer<'de> {
-    value: Option<&'de Key>,
+struct VariantDeserializer<'de, Float: FloatPolicy> {
+    value: Option<&'de Key<Float>>,
 }
 
-impl<'de> de::VariantAccess<'de> for VariantDeserializer<'de> {
+impl<'de, Float: FloatPolicy> de::VariantAccess<'de> for VariantDeserializer<'de, Float> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<(), Error> {
@@ -243,17 +291,17 @@ impl<'de> de::VariantAccess<'de> for VariantDeserializer<'de> {
     }
 }
 
-struct SeqDeserializer<'de> {
-    values: &'de [Key],
+struct SeqDeserializer<'de, Float: FloatPolicy> {
+    values: &'de [Key<Float>],
 }
 
-impl<'de> SeqDeserializer<'de> {
-    pub fn new(values: &'de [Key]) -> Self {
+impl<'de, Float: FloatPolicy> SeqDeserializer<'de, Float> {
+    pub fn new(values: &'de [Key<Float>]) -> Self {
         Self { values }
     }
 }
 
-impl<'de> serde::Deserializer<'de> for SeqDeserializer<'de> {
+impl<'de, Float: FloatPolicy> serde::Deserializer<'de> for SeqDeserializer<'de, Float> {
     type Error = Error;
 
     #[inline]
@@ -283,7 +331,7 @@ impl<'de> serde::Deserializer<'de> for SeqDeserializer<'de> {
     }
 }
 
-impl<'de> de::SeqAccess<'de> for SeqDeserializer<'de> {
+impl<'de, Float: FloatPolicy> de::SeqAccess<'de> for SeqDeserializer<'de, Float> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
@@ -301,18 +349,18 @@ impl<'de> de::SeqAccess<'de> for SeqDeserializer<'de> {
     }
 }
 
-struct MapDeserializer<'de> {
-    map: &'de [(Key, Key)],
-    value: Option<&'de Key>,
+struct MapDeserializer<'de, Float: FloatPolicy> {
+    map: &'de [(Key<Float>, Key<Float>)],
+    value: Option<&'de Key<Float>>,
 }
 
-impl<'de> MapDeserializer<'de> {
-    pub fn new(map: &'de [(Key, Key)]) -> Self {
+impl<'de, Float: FloatPolicy> MapDeserializer<'de, Float> {
+    pub fn new(map: &'de [(Key<Float>, Key<Float>)]) -> Self {
         Self { map, value: None }
     }
 }
 
-impl<'de> serde::Deserializer<'de> for MapDeserializer<'de> {
+impl<'de, Float: FloatPolicy> serde::Deserializer<'de> for MapDeserializer<'de, Float> {
     type Error = Error;
 
     #[inline]
@@ -330,7 +378,7 @@ impl<'de> serde::Deserializer<'de> for MapDeserializer<'de> {
     }
 }
 
-impl<'de> de::MapAccess<'de> for MapDeserializer<'de> {
+impl<'de, Float: FloatPolicy> de::MapAccess<'de> for MapDeserializer<'de, Float> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
@@ -363,23 +411,23 @@ impl<'de> de::MapAccess<'de> for MapDeserializer<'de> {
     }
 }
 
-impl<'de> de::Deserialize<'de> for Key {
+impl<'de, Float: FloatPolicy> de::Deserialize<'de> for Key<Float> {
     #[inline]
-    fn deserialize<D>(deserializer: D) -> Result<Key, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Key<Float>, D::Error>
     where
         D: de::Deserializer<'de>,
     {
-        struct ValueVisitor;
+        struct ValueVisitor<Float: FloatPolicy>(PhantomData<Float>);
 
-        impl<'de> de::Visitor<'de> for ValueVisitor {
-            type Value = Key;
+        impl<'de, Float: FloatPolicy> de::Visitor<'de> for ValueVisitor<Float> {
+            type Value = Key<Float>;
 
             fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
                 fmt.write_str("any valid key")
             }
 
             #[inline]
-            fn visit_str<E>(self, value: &str) -> Result<Key, E>
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
             where
                 E: de::Error,
             {
@@ -387,7 +435,7 @@ impl<'de> de::Deserialize<'de> for Key {
             }
 
             #[inline]
-            fn visit_string<E>(self, value: String) -> Result<Key, E>
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
             where
                 E: de::Error,
             {
@@ -529,7 +577,7 @@ impl<'de> de::Deserialize<'de> for Key {
             }
 
             #[inline]
-            fn visit_map<V>(self, mut visitor: V) -> Result<Key, V::Error>
+            fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
             where
                 V: de::MapAccess<'de>,
             {
@@ -543,6 +591,6 @@ impl<'de> de::Deserialize<'de> for Key {
             }
         }
 
-        deserializer.deserialize_any(ValueVisitor)
+        deserializer.deserialize_any(ValueVisitor::<Float>(PhantomData))
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,11 +1,12 @@
 //! Deserialization for serde-hashkey.
 
+use ordered_float::OrderedFloat;
 use serde::de::{self, IntoDeserializer};
 use std::fmt;
 
 use crate::{
     error::Error,
-    key::{Integer, Key},
+    key::{Float, Integer, Key},
 };
 
 /// Deserialize the given type from a [Key].
@@ -91,6 +92,8 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
             Key::Integer(Integer::I32(v)) => visitor.visit_i32(*v),
             Key::Integer(Integer::I64(v)) => visitor.visit_i64(*v),
             Key::Integer(Integer::I128(v)) => visitor.visit_i128(*v),
+            Key::Float(Float::F32(OrderedFloat(v))) => visitor.visit_f32(*v),
+            Key::Float(Float::F64(OrderedFloat(v))) => visitor.visit_f64(*v),
             Key::String(s) => visitor.visit_str(s),
             Key::Vec(array) => visitor.visit_seq(SeqDeserializer::new(array)),
             Key::Map(m) => visitor.visit_map(MapDeserializer::new(m)),

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::{error, fmt, result};
 
 /// Errors that can occur during serialization and deserialization of a
 /// [Key](crate::Key).
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     /// Unexpected type encountered.
     Unexpected(&'static str),

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,4 +1,5 @@
 //! In-memory value representation for values.
+use ordered_float::OrderedFloat;
 use std::mem;
 
 /// An opaque integer.
@@ -26,6 +27,15 @@ pub enum Integer {
     U128(u128),
 }
 
+/// An opaque floating-point type which has a total ordering.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Float {
+    /// Variant for an `f32`, in a wrapper implementing a total ordering.
+    F32(OrderedFloat<f32>),
+    /// Variant for an `f64`, in a wrapper implementing a total ordering.
+    F64(OrderedFloat<f64>),
+}
+
 /// The central key type, which is an in-memory representation of all supported
 /// serde-serialized values.
 ///
@@ -43,6 +53,8 @@ pub enum Key {
     Bool(bool),
     /// An integer.
     Integer(Integer),
+    /// A floating-point number.
+    Float(Float),
     /// A byte array.
     Bytes(Vec<u8>),
     /// A string.
@@ -94,6 +106,16 @@ macro_rules! impl_integer_from {
     };
 }
 
+macro_rules! impl_float_from {
+    ($variant:ident, $for_type:ty) => {
+        impl From<$for_type> for Key {
+            fn from(v: $for_type) -> Key {
+                Key::Float(Float::$variant(OrderedFloat(v)))
+            }
+        }
+    };
+}
+
 macro_rules! impl_from {
     ($variant:path, $for_type:ty) => {
         impl From<$for_type> for Key {
@@ -114,6 +136,9 @@ impl_integer_from!(U16, u16);
 impl_integer_from!(U32, u32);
 impl_integer_from!(U64, u64);
 impl_integer_from!(U128, u128);
+
+impl_float_from!(F32, f32);
+impl_float_from!(F64, f64);
 
 impl_from!(Key::Bool, bool);
 impl_from!(Key::Bytes, Vec<u8>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,11 @@
 //! This allows any serde-serializable type to be converted into a value which
 //! implements `PartialEq`, `Eq`, `ParialOrd`, `Ord`, and `Hash`. This can include
 //! floating point types such as `f32` and `f64` depending on the
-//! [`FloatPolicy`](key::FloatPolicy) used with the [`Key`](key::Key) type. By
+//! [FloatPolicy] used with the [Key] type. By
 //! default, attempts to serialize `f32` and `f64` will cause an error; this
 //! is because `f32` and `f64` are neither [totally ordered nor hashable] by default.
-//! To enable the [`Key`](key::Key) type to use `f32` and `f64`, parameterize
-//! it with the [`OrderedFloat`](key::OrderedFloat) policy, like so: `Key<OrderedFloat>`.
+//! To enable the [Key] type to use `f32` and `f64`, parameterize
+//! it with the [OrderedFloat] policy, like so: `Key<OrderedFloat>`.
 //!
 //! [Key] is useful because it allows for a form of type-erasure. Let's say you
 //! want to build a generic in-memory key-value store where you want to store
@@ -76,7 +76,10 @@
 //! ```
 //!
 //! [totally ordered nor hashable]: https://internals.rust-lang.org/t/f32-f64-should-implement-hash/5436
-//! [Key]: key::Key
+//! [Key]: https://docs.rs/serde-hashkey/0/serde_hashkey/enum.Key.html
+//! [FloatPolicy]: https://docs.rs/serde-hashkey/0/serde_hashkey/trait.FloatPolicy.html
+//! [RejectFloat]: https://docs.rs/serde-hashkey/0/serde_hashkey/enum.RejectFloat.html
+//! [OrderedFloat]: https://docs.rs/serde-hashkey/0/serde_hashkey/enum.OrderedFloat.html
 
 #![deny(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,13 @@
 //! Serde-based in-memory key serialization.
 //!
 //! This allows any serde-serializable type to be converted into a value which
-//! implements `PartialEq`, `Eq`, `ParialOrd`, `Ord`, and `Hash`. This includes
-//! floating point types such as `f32` and `f64` through the [`ordered-float`]
-//! crate, as those are neither [totally ordered nor hashable] by default.
+//! implements `PartialEq`, `Eq`, `ParialOrd`, `Ord`, and `Hash`. This can include
+//! floating point types such as `f32` and `f64` depending on the
+//! [`FloatPolicy`](key::FloatPolicy) used with the [`Key`](key::Key) type. By
+//! default, attempts to serialize `f32` and `f64` will cause an error; this
+//! is because `f32` and `f64` are neither [totally ordered nor hashable] by default.
+//! To enable the [`Key`](key::Key) type to use `f32` and `f64`, parameterize
+//! it with the [`OrderedFloat`](key::OrderedFloat) policy, like so: `Key<OrderedFloat>`.
 //!
 //! [Key] is useful because it allows for a form of type-erasure. Let's say you
 //! want to build a generic in-memory key-value store where you want to store
@@ -72,7 +76,7 @@
 //! ```
 //!
 //! [totally ordered nor hashable]: https://internals.rust-lang.org/t/f32-f64-should-implement-hash/5436
-//! [Key]: https://docs.rs/serde-hashkey/0/serde_hashkey/enum.Key.html
+//! [Key]: key::Key
 
 #![deny(missing_docs)]
 
@@ -82,10 +86,10 @@ mod key;
 mod ser;
 
 #[doc(inline)]
-pub use crate::de::from_key;
+pub use crate::de::{from_key, from_key_with_policy};
 #[doc(inline)]
 pub use crate::error::{Error, Result};
 #[doc(inline)]
-pub use crate::key::{Float, Integer, Key};
+pub use crate::key::{FloatPolicy, Integer, Key, OrderedFloat, RejectFloat};
 #[doc(inline)]
-pub use crate::ser::to_key;
+pub use crate::ser::{to_key, to_key_with_policy};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,9 @@
 //! Serde-based in-memory key serialization.
 //!
 //! This allows any serde-serializable type to be converted into a value which
-//! implements `PartialEq`, `Eq`, `ParialOrd`, `Ord`, and `Hash`. The only
-//! limitation is that the type can't serialize floating point values, since
-//! these are not [totally ordered nor hashable] by default.
+//! implements `PartialEq`, `Eq`, `ParialOrd`, `Ord`, and `Hash`. This includes
+//! floating point types such as `f32` and `f64` through the [`ordered-float`]
+//! crate, as those are neither [totally ordered nor hashable] by default.
 //!
 //! [Key] is useful because it allows for a form of type-erasure. Let's say you
 //! want to build a generic in-memory key-value store where you want to store
@@ -86,6 +86,6 @@ pub use crate::de::from_key;
 #[doc(inline)]
 pub use crate::error::{Error, Result};
 #[doc(inline)]
-pub use crate::key::{Integer, Key};
+pub use crate::key::{Float, Integer, Key};
 #[doc(inline)]
 pub use crate::ser::to_key;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,10 +1,11 @@
 //! Serialization for serde-hashkey.
 
 use crate::error::Error;
-use ordered_float::OrderedFloat;
 use serde::ser;
+use std::convert::TryInto;
+use std::marker::PhantomData;
 
-use crate::key::{Float, Integer, Key};
+use crate::key::{FloatPolicy, FloatProxy, Integer, Key};
 
 /// Serialize the given value to a [Key].
 ///
@@ -47,10 +48,55 @@ pub fn to_key<T>(value: &T) -> Result<Key, Error>
 where
     T: ser::Serialize,
 {
-    value.serialize(Serializer)
+    value.serialize(Serializer(PhantomData))
 }
 
-impl ser::Serialize for Key {
+/// Serialize the given value to a [Key], with a non-default [`FloatPolicy`](key::FloatPolicy).
+///
+/// # Examples
+///
+/// ```rust
+/// use serde_derive::{Deserialize, Serialize};
+/// use serde_hashkey::{from_key_with_policy, to_key_with_policy, OrderedFloat, Key};
+/// use std::collections::HashMap;
+///
+/// #[derive(Debug, PartialEq, Serialize, Deserialize)]
+/// struct Author {
+///     name: String,
+///     age: f32,
+/// }
+///
+/// #[derive(Debug, PartialEq, Serialize, Deserialize)]
+/// struct Book {
+///     title: String,
+///     author: Author,
+/// }
+///
+/// # fn main() -> serde_hashkey::Result<()> {
+/// let book = Book {
+///     title: String::from("Birds of a feather"),
+///     author: Author {
+///         name: String::from("Noah"),
+///         age: 42.5,
+///     },
+/// };
+///
+/// let key = to_key_with_policy::<OrderedFloat, _>(&book)?;
+/// let book2 = from_key_with_policy::<OrderedFloat, _>(&key)?;
+///
+/// assert_eq!(book, book2);
+/// # Ok(())
+/// # }
+/// ```
+pub fn to_key_with_policy<Float, T>(value: &T) -> Result<Key<Float>, Error>
+where
+    Float: FloatPolicy,
+    T: ser::Serialize,
+{
+    value.serialize(Serializer(PhantomData))
+}
+
+impl<Float: FloatPolicy> ser::Serialize for Key<Float> {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -68,8 +114,10 @@ impl ser::Serialize for Key {
             Key::Integer(Integer::I32(v)) => serializer.serialize_i32(*v),
             Key::Integer(Integer::I64(v)) => serializer.serialize_i64(*v),
             Key::Integer(Integer::I128(v)) => serializer.serialize_i128(*v),
-            Key::Float(Float::F32(OrderedFloat(v))) => serializer.serialize_f32(*v),
-            Key::Float(Float::F64(OrderedFloat(v))) => serializer.serialize_f64(*v),
+            Key::Float(float) => match float.clone().into() {
+                FloatProxy::F32(v) => serializer.serialize_f32(v),
+                FloatProxy::F64(v) => serializer.serialize_f64(v),
+            },
             Key::Bytes(v) => serializer.serialize_bytes(&v),
             Key::String(v) => serializer.serialize_str(&v),
             Key::Vec(v) => v.serialize(serializer),
@@ -90,107 +138,107 @@ impl ser::Serialize for Key {
     }
 }
 
-struct Serializer;
+struct Serializer<Float: FloatPolicy>(PhantomData<Float>);
 
-impl ser::Serializer for Serializer {
-    type Ok = Key;
+impl<Float: FloatPolicy> ser::Serializer for Serializer<Float> {
+    type Ok = Key<Float>;
     type Error = Error;
 
-    type SerializeSeq = SerializeVec;
-    type SerializeTuple = SerializeVec;
-    type SerializeTupleStruct = SerializeVec;
-    type SerializeTupleVariant = SerializeTupleVariant;
-    type SerializeMap = SerializeMap;
-    type SerializeStruct = SerializeMap;
-    type SerializeStructVariant = SerializeStructVariant;
+    type SerializeSeq = SerializeVec<Float>;
+    type SerializeTuple = SerializeVec<Float>;
+    type SerializeTupleStruct = SerializeVec<Float>;
+    type SerializeTupleVariant = SerializeTupleVariant<Float>;
+    type SerializeMap = SerializeMap<Float>;
+    type SerializeStruct = SerializeMap<Float>;
+    type SerializeStructVariant = SerializeStructVariant<Float>;
 
     #[inline]
-    fn serialize_bool(self, value: bool) -> Result<Key, Error> {
+    fn serialize_bool(self, value: bool) -> Result<Key<Float>, Error> {
         Ok(Key::Bool(value))
     }
 
     #[inline]
-    fn serialize_i8(self, value: i8) -> Result<Key, Error> {
+    fn serialize_i8(self, value: i8) -> Result<Key<Float>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_i16(self, value: i16) -> Result<Key, Error> {
+    fn serialize_i16(self, value: i16) -> Result<Key<Float>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_i32(self, value: i32) -> Result<Key, Error> {
+    fn serialize_i32(self, value: i32) -> Result<Key<Float>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_i64(self, value: i64) -> Result<Key, Error> {
+    fn serialize_i64(self, value: i64) -> Result<Key<Float>, Error> {
         Ok(value.into())
     }
 
-    fn serialize_i128(self, value: i128) -> Result<Key, Error> {
-        Ok(value.into())
-    }
-
-    #[inline]
-    fn serialize_u8(self, value: u8) -> Result<Key, Error> {
+    fn serialize_i128(self, value: i128) -> Result<Key<Float>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_u16(self, value: u16) -> Result<Key, Error> {
+    fn serialize_u8(self, value: u8) -> Result<Key<Float>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_u32(self, value: u32) -> Result<Key, Error> {
+    fn serialize_u16(self, value: u16) -> Result<Key<Float>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_u64(self, value: u64) -> Result<Key, Error> {
+    fn serialize_u32(self, value: u32) -> Result<Key<Float>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_u128(self, value: u128) -> Result<Key, Error> {
+    fn serialize_u64(self, value: u64) -> Result<Key<Float>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_f32(self, value: f32) -> Result<Key, Error> {
+    fn serialize_u128(self, value: u128) -> Result<Key<Float>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_f64(self, value: f64) -> Result<Key, Error> {
-        Ok(value.into())
+    fn serialize_f32(self, value: f32) -> Result<Key<Float>, Error> {
+        value.try_into()
     }
 
     #[inline]
-    fn serialize_char(self, value: char) -> Result<Key, Error> {
+    fn serialize_f64(self, value: f64) -> Result<Key<Float>, Error> {
+        value.try_into()
+    }
+
+    #[inline]
+    fn serialize_char(self, value: char) -> Result<Key<Float>, Error> {
         let mut s = String::new();
         s.push(value);
         self.serialize_str(&s)
     }
 
     #[inline]
-    fn serialize_str(self, value: &str) -> Result<Key, Error> {
+    fn serialize_str(self, value: &str) -> Result<Key<Float>, Error> {
         Ok(Key::String(value.to_owned()))
     }
 
-    fn serialize_bytes(self, value: &[u8]) -> Result<Key, Error> {
+    fn serialize_bytes(self, value: &[u8]) -> Result<Key<Float>, Error> {
         Ok(Key::Bytes(value.to_vec()))
     }
 
     #[inline]
-    fn serialize_unit(self) -> Result<Key, Error> {
+    fn serialize_unit(self) -> Result<Key<Float>, Error> {
         Ok(Key::Unit)
     }
 
     #[inline]
-    fn serialize_unit_struct(self, _name: &'static str) -> Result<Key, Error> {
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Key<Float>, Error> {
         self.serialize_unit()
     }
 
@@ -200,7 +248,7 @@ impl ser::Serializer for Serializer {
         _name: &'static str,
         _variant_index: u32,
         variant: &'static str,
-    ) -> Result<Key, Error> {
+    ) -> Result<Key<Float>, Error> {
         self.serialize_str(variant)
     }
 
@@ -209,7 +257,7 @@ impl ser::Serializer for Serializer {
         self,
         _name: &'static str,
         value: &T,
-    ) -> Result<Key, Error>
+    ) -> Result<Key<Float>, Error>
     where
         T: ser::Serialize,
     {
@@ -222,21 +270,21 @@ impl ser::Serializer for Serializer {
         _variant_index: u32,
         variant: &'static str,
         value: &T,
-    ) -> Result<Key, Error>
+    ) -> Result<Key<Float>, Error>
     where
         T: ser::Serialize,
     {
-        let value = (Key::from(variant.to_owned()), to_key(&value)?);
+        let value = (Key::from(variant.to_owned()), to_key_with_policy(&value)?);
         Ok(Key::Map(vec![value]))
     }
 
     #[inline]
-    fn serialize_none(self) -> Result<Key, Error> {
+    fn serialize_none(self) -> Result<Key<Float>, Error> {
         self.serialize_unit()
     }
 
     #[inline]
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Key, Error>
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Key<Float>, Error>
     where
         T: ser::Serialize,
     {
@@ -308,44 +356,44 @@ impl ser::Serializer for Serializer {
     }
 }
 
-pub struct SerializeVec {
-    vec: Vec<Key>,
+pub struct SerializeVec<Float: FloatPolicy> {
+    vec: Vec<Key<Float>>,
 }
 
-pub struct SerializeTupleVariant {
+pub struct SerializeTupleVariant<Float: FloatPolicy> {
     name: String,
-    vec: Vec<Key>,
+    vec: Vec<Key<Float>>,
 }
 
-pub struct SerializeMap {
-    map: Vec<(Key, Key)>,
-    next_key: Option<Key>,
+pub struct SerializeMap<Float: FloatPolicy> {
+    map: Vec<(Key<Float>, Key<Float>)>,
+    next_key: Option<Key<Float>>,
 }
 
-pub struct SerializeStructVariant {
+pub struct SerializeStructVariant<Float: FloatPolicy> {
     name: String,
-    map: Vec<(Key, Key)>,
+    map: Vec<(Key<Float>, Key<Float>)>,
 }
 
-impl ser::SerializeSeq for SerializeVec {
-    type Ok = Key;
+impl<Float: FloatPolicy> ser::SerializeSeq for SerializeVec<Float> {
+    type Ok = Key<Float>;
     type Error = Error;
 
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
     where
         T: ser::Serialize,
     {
-        self.vec.push(to_key(&value)?);
+        self.vec.push(to_key_with_policy(&value)?);
         Ok(())
     }
 
-    fn end(self) -> Result<Key, Error> {
+    fn end(self) -> Result<Key<Float>, Error> {
         Ok(Key::Vec(self.vec))
     }
 }
 
-impl ser::SerializeTuple for SerializeVec {
-    type Ok = Key;
+impl<Float: FloatPolicy> ser::SerializeTuple for SerializeVec<Float> {
+    type Ok = Key<Float>;
     type Error = Error;
 
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
@@ -355,13 +403,13 @@ impl ser::SerializeTuple for SerializeVec {
         ser::SerializeSeq::serialize_element(self, value)
     }
 
-    fn end(self) -> Result<Key, Error> {
+    fn end(self) -> Result<Key<Float>, Error> {
         ser::SerializeSeq::end(self)
     }
 }
 
-impl ser::SerializeTupleStruct for SerializeVec {
-    type Ok = Key;
+impl<Float: FloatPolicy> ser::SerializeTupleStruct for SerializeVec<Float> {
+    type Ok = Key<Float>;
     type Error = Error;
 
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
@@ -371,38 +419,38 @@ impl ser::SerializeTupleStruct for SerializeVec {
         ser::SerializeSeq::serialize_element(self, value)
     }
 
-    fn end(self) -> Result<Key, Error> {
+    fn end(self) -> Result<Key<Float>, Error> {
         ser::SerializeSeq::end(self)
     }
 }
 
-impl ser::SerializeTupleVariant for SerializeTupleVariant {
-    type Ok = Key;
+impl<Float: FloatPolicy> ser::SerializeTupleVariant for SerializeTupleVariant<Float> {
+    type Ok = Key<Float>;
     type Error = Error;
 
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
     where
         T: ser::Serialize,
     {
-        self.vec.push(to_key(&value)?);
+        self.vec.push(to_key_with_policy(&value)?);
         Ok(())
     }
 
-    fn end(self) -> Result<Key, Error> {
+    fn end(self) -> Result<Key<Float>, Error> {
         let value = (Key::from(self.name), Key::Vec(self.vec));
         Ok(Key::Map(vec![value]))
     }
 }
 
-impl ser::SerializeMap for SerializeMap {
-    type Ok = Key;
+impl<Float: FloatPolicy> ser::SerializeMap for SerializeMap<Float> {
+    type Ok = Key<Float>;
     type Error = Error;
 
     fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Error>
     where
         T: ser::Serialize,
     {
-        self.next_key = Some(Key::from(to_key(&key)?));
+        self.next_key = Some(Key::from(to_key_with_policy(&key)?));
         Ok(())
     }
 
@@ -415,17 +463,17 @@ impl ser::SerializeMap for SerializeMap {
             None => return Err(Error::MissingValue),
         };
 
-        self.map.push((key, to_key(&value)?));
+        self.map.push((key, to_key_with_policy(&value)?));
         Ok(())
     }
 
-    fn end(self) -> Result<Key, Error> {
+    fn end(self) -> Result<Key<Float>, Error> {
         Ok(Key::Map(self.map))
     }
 }
 
-impl ser::SerializeStruct for SerializeMap {
-    type Ok = Key;
+impl<Float: FloatPolicy> ser::SerializeStruct for SerializeMap<Float> {
+    type Ok = Key<Float>;
     type Error = Error;
 
     fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
@@ -436,13 +484,13 @@ impl ser::SerializeStruct for SerializeMap {
         ser::SerializeMap::serialize_value(self, value)
     }
 
-    fn end(self) -> Result<Key, Error> {
+    fn end(self) -> Result<Key<Float>, Error> {
         ser::SerializeMap::end(self)
     }
 }
 
-impl ser::SerializeStructVariant for SerializeStructVariant {
-    type Ok = Key;
+impl<Float: FloatPolicy> ser::SerializeStructVariant for SerializeStructVariant<Float> {
+    type Ok = Key<Float>;
     type Error = Error;
 
     fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
@@ -450,11 +498,11 @@ impl ser::SerializeStructVariant for SerializeStructVariant {
         T: ser::Serialize,
     {
         self.map
-            .push((Key::from(String::from(key)), to_key(&value)?));
+            .push((Key::from(String::from(key)), to_key_with_policy(&value)?));
         Ok(())
     }
 
-    fn end(self) -> Result<Key, Error> {
+    fn end(self) -> Result<Key<Float>, Error> {
         let value = (Key::from(self.name), Key::Map(self.map));
         Ok(Key::Map(vec![value]))
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -43,28 +43,6 @@ use crate::key::{Float, Integer, Key};
 /// # Ok(())
 /// # }
 /// ```
-///
-/// Attempting to serialize a float causes an error:
-///
-/// ```rust
-/// use serde_derive::Serialize;
-/// use serde_hashkey::{to_key, Key};
-///
-/// #[derive(Debug, PartialEq, Serialize)]
-/// struct Npc {
-///     health: f32,
-/// }
-///
-/// # fn main() -> serde_hashkey::Result<()> {
-/// let npc = Npc {
-///     health: 0.8,
-/// };
-///
-/// let result = to_key(&npc);
-/// assert!(result.is_err());
-/// # Ok(())
-/// # }
-/// ```
 pub fn to_key<T>(value: &T) -> Result<Key, Error>
 where
     T: ser::Serialize,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -2,10 +2,9 @@
 
 use crate::error::Error;
 use serde::ser;
-use std::convert::TryInto;
 use std::marker::PhantomData;
 
-use crate::key::{FloatPolicy, FloatProxy, Integer, Key};
+use crate::key::{FloatPolicy, Integer, Key};
 
 /// Serialize the given value to a [Key].
 ///
@@ -114,10 +113,7 @@ impl<Float: FloatPolicy> ser::Serialize for Key<Float> {
             Key::Integer(Integer::I32(v)) => serializer.serialize_i32(*v),
             Key::Integer(Integer::I64(v)) => serializer.serialize_i64(*v),
             Key::Integer(Integer::I128(v)) => serializer.serialize_i128(*v),
-            Key::Float(float) => match float.clone().into() {
-                FloatProxy::F32(v) => serializer.serialize_f32(v),
-                FloatProxy::F64(v) => serializer.serialize_f64(v),
-            },
+            Key::Float(float) => float.serialize_float(serializer),
             Key::Bytes(v) => serializer.serialize_bytes(&v),
             Key::String(v) => serializer.serialize_str(&v),
             Key::Vec(v) => v.serialize(serializer),
@@ -208,12 +204,12 @@ impl<Float: FloatPolicy> ser::Serializer for Serializer<Float> {
 
     #[inline]
     fn serialize_f32(self, value: f32) -> Result<Key<Float>, Error> {
-        value.try_into()
+        Float::serialize_f32(value).map(Key::Float)
     }
 
     #[inline]
     fn serialize_f64(self, value: f64) -> Result<Key<Float>, Error> {
-        value.try_into()
+        Float::serialize_f64(value).map(Key::Float)
     }
 
     #[inline]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,9 +1,10 @@
 //! Serialization for serde-hashkey.
 
 use crate::error::Error;
+use ordered_float::OrderedFloat;
 use serde::ser;
 
-use crate::key::{Integer, Key};
+use crate::key::{Float, Integer, Key};
 
 /// Serialize the given value to a [Key].
 ///
@@ -89,6 +90,8 @@ impl ser::Serialize for Key {
             Key::Integer(Integer::I32(v)) => serializer.serialize_i32(*v),
             Key::Integer(Integer::I64(v)) => serializer.serialize_i64(*v),
             Key::Integer(Integer::I128(v)) => serializer.serialize_i128(*v),
+            Key::Float(Float::F32(OrderedFloat(v))) => serializer.serialize_f32(*v),
+            Key::Float(Float::F64(OrderedFloat(v))) => serializer.serialize_f64(*v),
             Key::Bytes(v) => serializer.serialize_bytes(&v),
             Key::String(v) => serializer.serialize_str(&v),
             Key::Vec(v) => v.serialize(serializer),
@@ -178,13 +181,13 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn serialize_f32(self, _: f32) -> Result<Key, Error> {
-        Err(Error::UnsupportedType("f32"))
+    fn serialize_f32(self, value: f32) -> Result<Key, Error> {
+        Ok(value.into())
     }
 
     #[inline]
-    fn serialize_f64(self, _: f64) -> Result<Key, Error> {
-        Err(Error::UnsupportedType("f64"))
+    fn serialize_f64(self, value: f64) -> Result<Key, Error> {
+        Ok(value.into())
     }
 
     #[inline]

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -1,5 +1,5 @@
 use serde_derive::{Deserialize, Serialize};
-use serde_hashkey::{from_key, to_key, Error, Integer, Key};
+use serde_hashkey::{from_key, to_key, to_key_with_policy, Error, Integer, Key, OrderedFloat};
 use std::collections::BTreeMap;
 
 #[test]
@@ -87,4 +87,18 @@ fn test_normalize() {
     assert_ne!(a, b);
     assert_eq!(a, b.clone().normalize());
     assert_eq!(a.clone().normalize(), b.clone().normalize());
+}
+
+#[test]
+fn deny_floats_by_default() {
+    assert_eq!(to_key(&0f32), Err(Error::UnsupportedType("f32")));
+    assert_eq!(to_key(&0f64), Err(Error::UnsupportedType("f64")));
+    assert_eq!(
+        to_key_with_policy::<OrderedFloat, _>(&0f32),
+        Ok(Key::Float(OrderedFloat::F32(0f32)))
+    );
+    assert_eq!(
+        to_key_with_policy::<OrderedFloat, _>(&0f64),
+        Ok(Key::Float(OrderedFloat::F64(0f64)))
+    );
 }


### PR DESCRIPTION
Hulloooo! Back with another PR. This one I'm not sure how you'll feel about; it adds support for `f32` and `f64` by using the `OrderedFloat` wrapper from the `ordered-float` crate. Since the `Key` type is exposed and the `Float` type is exposed as well, this ends up exposing a foreign type as part of the public API. Happy to find a workaround/write a wrapper that doesn't expose it as such if necessary.