### PR TITLE
Associated types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,18 @@ keywords = ["serde", "serialization"]
 categories = ["encoding"]
 edition = "2018"
 
+[features]
+default = []
+ordered-float = ["ordered-float2", "num-traits02"]
+
 [dependencies]
 serde = "1.0.117"
-ordered-float = { version = "2.0.0", optional = true }
+ordered-float2 = { package = "ordered-float", version = "2.0.0", optional = true }
+num-traits02 = { package = "num-traits", version = "0.2.1", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.59"
 serde_derive = "1.0.117"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ categories = ["encoding"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.98" }
+serde = "1.0.117"
 ordered-float = { version = "2.0.0", optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.40"
-serde_derive = "1"
+serde_json = "1.0.59"
+serde_derive = "1.0.117"

--- a/README.md
+++ b/README.md
@@ -13,14 +13,31 @@
 Serde-based in-memory key serialization.
 
 This allows any serde-serializable type to be converted into a value which
-implements `PartialEq`, `Eq`, `ParialOrd`, `Ord`, and `Hash`. The only
-limitation is that the type can't serialize floating point values, since
-these are not [totally ordered nor hashable] by default.
+implements `PartialEq`, `Eq`, `ParialOrd`, `Ord`, and `Hash`.
 
 [Key] is useful because it allows for a form of type-erasure. Let's say you
 want to build a generic in-memory key-value store where you want to store
 arbitrary serde-serializable keys. This is typical for things like caches or
 dependency injection frameworks.
+
+### Float policies
+
+By default, [Key] can't include floating point types such as `f32` and
+`f64`. Neither of these are [totally ordered nor hashable].
+
+To enable the [Key] type to use `f32` and `f64` it can be constructed with a
+specific float policy.
+
+Available float policies are:
+* [RejectFloat] - the default behavior when using [to_key].
+* [OrderedFloat] - the behavior when using [to_key_with_ordered_float]. The
+  `ordered-float` feature must be enabled to use this. The behavior is
+  derived from the [`ordered-float` crate].
+
+### Features
+
+* `ordered-float` - Enables serializing floating point numbers through
+  behavior derived from the [`ordered-float` crate]
 
 ### Examples
 
@@ -75,5 +92,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
 [totally ordered nor hashable]: https://internals.rust-lang.org/t/f32-f64-should-implement-hash/5436
 [Key]: https://docs.rs/serde-hashkey/0/serde_hashkey/enum.Key.html
+[to_key]: https://docs.rs/serde-hashkey/0/serde_hashkey/fn.to_key.html
+[RejectFloat]: https://docs.rs/serde-hashkey/0/serde_hashkey/enum.RejectFloat.html
+[OrderedFloat]: https://docs.rs/serde-hashkey/0/serde_hashkey/enum.OrderedFloat.html
+[to_key_with_ordered_float]: https://docs.rs/serde-hashkey/0/serde_hashkey/fn.to_key_with_ordered_float.html
+[`ordered-float` crate]: https://docs.rs/ordered-float/2/ordered_float/
 
 License: MIT/Apache-2.0

--- a/src/de.rs
+++ b/src/de.rs
@@ -89,25 +89,37 @@ where
     T::deserialize(Deserializer::new(&value))
 }
 
-impl<'de, Float: FloatPolicy> IntoDeserializer<'de, Error> for &'de Key<Float> {
-    type Deserializer = Deserializer<'de, Float>;
+impl<'de, F> IntoDeserializer<'de, Error> for &'de Key<F>
+where
+    F: FloatPolicy,
+{
+    type Deserializer = Deserializer<'de, F>;
 
     fn into_deserializer(self) -> Self::Deserializer {
         Deserializer::new(self)
     }
 }
 
-pub struct Deserializer<'de, Float: FloatPolicy> {
-    value: &'de Key<Float>,
+pub struct Deserializer<'de, F>
+where
+    F: FloatPolicy,
+{
+    value: &'de Key<F>,
 }
 
-impl<'de, Float: FloatPolicy> Deserializer<'de, Float> {
-    pub fn new(value: &'de Key<Float>) -> Self {
+impl<'de, F> Deserializer<'de, F>
+where
+    F: FloatPolicy,
+{
+    pub fn new(value: &'de Key<F>) -> Self {
         Self { value }
     }
 }
 
-impl<'de, Float: FloatPolicy> de::Deserializer<'de> for Deserializer<'de, Float> {
+impl<'de, F> de::Deserializer<'de> for Deserializer<'de, F>
+where
+    F: FloatPolicy,
+{
     type Error = Error;
 
     #[inline]
@@ -204,14 +216,20 @@ impl<'de, Float: FloatPolicy> de::Deserializer<'de> for Deserializer<'de, Float>
     }
 }
 
-struct EnumDeserializer<'de, Float: FloatPolicy> {
-    variant: &'de Key<Float>,
-    value: Option<&'de Key<Float>>,
+struct EnumDeserializer<'de, F>
+where
+    F: FloatPolicy,
+{
+    variant: &'de Key<F>,
+    value: Option<&'de Key<F>>,
 }
 
-impl<'de, Float: FloatPolicy> de::EnumAccess<'de> for EnumDeserializer<'de, Float> {
+impl<'de, F> de::EnumAccess<'de> for EnumDeserializer<'de, F>
+where
+    F: FloatPolicy,
+{
     type Error = Error;
-    type Variant = VariantDeserializer<'de, Float>;
+    type Variant = VariantDeserializer<'de, F>;
 
     fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Error>
     where
@@ -223,11 +241,17 @@ impl<'de, Float: FloatPolicy> de::EnumAccess<'de> for EnumDeserializer<'de, Floa
     }
 }
 
-struct VariantDeserializer<'de, Float: FloatPolicy> {
-    value: Option<&'de Key<Float>>,
+struct VariantDeserializer<'de, F>
+where
+    F: FloatPolicy,
+{
+    value: Option<&'de Key<F>>,
 }
 
-impl<'de, Float: FloatPolicy> de::VariantAccess<'de> for VariantDeserializer<'de, Float> {
+impl<'de, F> de::VariantAccess<'de> for VariantDeserializer<'de, F>
+where
+    F: FloatPolicy,
+{
     type Error = Error;
 
     fn unit_variant(self) -> Result<(), Error> {
@@ -278,17 +302,26 @@ impl<'de, Float: FloatPolicy> de::VariantAccess<'de> for VariantDeserializer<'de
     }
 }
 
-struct SeqDeserializer<'de, Float: FloatPolicy> {
-    values: &'de [Key<Float>],
+struct SeqDeserializer<'de, F>
+where
+    F: FloatPolicy,
+{
+    values: &'de [Key<F>],
 }
 
-impl<'de, Float: FloatPolicy> SeqDeserializer<'de, Float> {
-    pub fn new(values: &'de [Key<Float>]) -> Self {
+impl<'de, F> SeqDeserializer<'de, F>
+where
+    F: FloatPolicy,
+{
+    pub fn new(values: &'de [Key<F>]) -> Self {
         Self { values }
     }
 }
 
-impl<'de, Float: FloatPolicy> serde::Deserializer<'de> for SeqDeserializer<'de, Float> {
+impl<'de, F> serde::Deserializer<'de> for SeqDeserializer<'de, F>
+where
+    F: FloatPolicy,
+{
     type Error = Error;
 
     #[inline]
@@ -318,7 +351,10 @@ impl<'de, Float: FloatPolicy> serde::Deserializer<'de> for SeqDeserializer<'de, 
     }
 }
 
-impl<'de, Float: FloatPolicy> de::SeqAccess<'de> for SeqDeserializer<'de, Float> {
+impl<'de, F> de::SeqAccess<'de> for SeqDeserializer<'de, F>
+where
+    F: FloatPolicy,
+{
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
@@ -336,18 +372,27 @@ impl<'de, Float: FloatPolicy> de::SeqAccess<'de> for SeqDeserializer<'de, Float>
     }
 }
 
-struct MapDeserializer<'de, Float: FloatPolicy> {
-    map: &'de [(Key<Float>, Key<Float>)],
-    value: Option<&'de Key<Float>>,
+struct MapDeserializer<'de, F>
+where
+    F: FloatPolicy,
+{
+    map: &'de [(Key<F>, Key<F>)],
+    value: Option<&'de Key<F>>,
 }
 
-impl<'de, Float: FloatPolicy> MapDeserializer<'de, Float> {
-    pub fn new(map: &'de [(Key<Float>, Key<Float>)]) -> Self {
+impl<'de, F> MapDeserializer<'de, F>
+where
+    F: FloatPolicy,
+{
+    pub fn new(map: &'de [(Key<F>, Key<F>)]) -> Self {
         Self { map, value: None }
     }
 }
 
-impl<'de, Float: FloatPolicy> serde::Deserializer<'de> for MapDeserializer<'de, Float> {
+impl<'de, F> serde::Deserializer<'de> for MapDeserializer<'de, F>
+where
+    F: FloatPolicy,
+{
     type Error = Error;
 
     #[inline]
@@ -365,7 +410,10 @@ impl<'de, Float: FloatPolicy> serde::Deserializer<'de> for MapDeserializer<'de, 
     }
 }
 
-impl<'de, Float: FloatPolicy> de::MapAccess<'de> for MapDeserializer<'de, Float> {
+impl<'de, F> de::MapAccess<'de> for MapDeserializer<'de, F>
+where
+    F: FloatPolicy,
+{
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
@@ -398,16 +446,24 @@ impl<'de, Float: FloatPolicy> de::MapAccess<'de> for MapDeserializer<'de, Float>
     }
 }
 
-impl<'de, Float: FloatPolicy> de::Deserialize<'de> for Key<Float> {
+impl<'de, F> de::Deserialize<'de> for Key<F>
+where
+    F: FloatPolicy,
+{
     #[inline]
-    fn deserialize<D>(deserializer: D) -> Result<Key<Float>, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Key<F>, D::Error>
     where
         D: de::Deserializer<'de>,
     {
-        struct ValueVisitor<Float: FloatPolicy>(PhantomData<Float>);
+        struct ValueVisitor<F>(PhantomData<F>)
+        where
+            F: FloatPolicy;
 
-        impl<'de, Float: FloatPolicy> de::Visitor<'de> for ValueVisitor<Float> {
-            type Value = Key<Float>;
+        impl<'de, F> de::Visitor<'de> for ValueVisitor<F>
+        where
+            F: FloatPolicy,
+        {
+            type Value = Key<F>;
 
             fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
                 fmt.write_str("any valid key")
@@ -578,6 +634,6 @@ impl<'de, Float: FloatPolicy> de::Deserialize<'de> for Key<Float> {
             }
         }
 
-        deserializer.deserialize_any(ValueVisitor::<Float>(PhantomData))
+        deserializer.deserialize_any(ValueVisitor::<F>(PhantomData))
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -45,20 +45,12 @@ use crate::key::{Integer, Key};
 /// # Ok(())
 /// # }
 /// ```
-pub fn from_key<T>(value: &Key) -> Result<T, crate::error::Error>
-where
-    T: de::DeserializeOwned,
-{
-    T::deserialize(Deserializer::new(&value))
-}
-
-/// Deserialize the given type from a [Key], with a non-default [`FloatPolicy`](key::FloatPolicy).
 ///
-/// # Examples
+/// Using a non-standard float policy:
 ///
 /// ```rust
 /// use serde_derive::{Deserialize, Serialize};
-/// use serde_hashkey::{from_key_with_policy, to_key_with_policy, OrderedFloat, Key};
+/// use serde_hashkey::{from_key, to_key_with_ordered_float, OrderedFloat, Key};
 /// use std::collections::HashMap;
 ///
 /// #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -82,17 +74,17 @@ where
 ///     },
 /// };
 ///
-/// let key = to_key_with_policy::<OrderedFloat, _>(&book)?;
-/// let book2 = from_key_with_policy::<OrderedFloat, _>(&key)?;
+/// let key = to_key_with_ordered_float(&book)?;
+/// let book2 = from_key(&key)?;
 ///
 /// assert_eq!(book, book2);
 /// # Ok(())
 /// # }
 /// ```
-pub fn from_key_with_policy<Float, T>(value: &Key<Float>) -> Result<T, crate::error::Error>
+pub fn from_key<T, F>(value: &Key<F>) -> Result<T, crate::error::Error>
 where
-    Float: FloatPolicy,
     T: de::DeserializeOwned,
+    F: FloatPolicy,
 {
     T::deserialize(Deserializer::new(&value))
 }

--- a/src/float/float_policy.rs
+++ b/src/float/float_policy.rs
@@ -1,0 +1,40 @@
+use crate::float::FloatRepr;
+
+/// A policy for handling floating point types in a `Key`.
+///
+/// Currently there are two important `FloatPolicy` types: [RejectFloatPolicy]
+/// and [OrderedFloat]. The former will emit errors instead of allowing floats
+/// to be serialized and the latter while serialize them and provide a total
+/// order which does not adhere to the IEEE standard.
+///
+/// [RejectFloatPolicy]: crate::RejectFloatPolicy
+/// [OrderedFloat]: crate::OrderedFloat
+///
+/// # Examples
+///
+/// Example using a non-default float policy:
+///
+/// ```rust
+/// use serde_hashkey::{Key, Float, to_key_with_ordered_float, OrderedFloat, OrderedFloatPolicy};
+///
+/// # fn main() -> Result<(), serde_hashkey::Error> {
+/// let a: Key<OrderedFloatPolicy> = to_key_with_ordered_float(&42.42f32)?;
+/// assert!(matches!(a, Key::Float(Float::F32(OrderedFloat(..)))));
+///
+/// let b: Key<OrderedFloatPolicy> = to_key_with_ordered_float(&42.42f64)?;
+/// assert!(matches!(b, Key::Float(Float::F64(OrderedFloat(..)))));
+/// # Ok(()) }
+/// ```
+pub trait FloatPolicy: self::private::Sealed {
+    /// The type encapsulating a 32-bit float, or `f32`.
+    type F32: FloatRepr<f32>;
+
+    /// The type encapsulating a 64-bit float, or `f64`.
+    type F64: FloatRepr<f64>;
+}
+
+// NB: we completely seal the FloatPolicy to prevent external implementations.
+mod private {
+    pub trait Sealed {}
+    impl<T> Sealed for T where T: super::FloatPolicy {}
+}

--- a/src/float/float_repr.rs
+++ b/src/float/float_repr.rs
@@ -1,0 +1,37 @@
+use crate::error::Error;
+use serde::{de, ser};
+use std::cmp;
+use std::fmt;
+use std::hash;
+
+/// Trait implemented by floating point types which can be used in a
+/// [FloatPolicy]. This is implemented by the type representing a float,
+/// typically a wrapper, and defines the protocol necessary to incorporate the
+/// floating point type `T` into the [Key] protocol.
+///
+/// [Key]: crate::Key
+/// [FloatPolicy]: crate::FloatPolicy
+pub trait FloatRepr<T>:
+    self::private::Sealed<T>
+    + Copy
+    + Sized
+    + fmt::Debug
+    + ser::Serialize
+    + cmp::Eq
+    + cmp::Ord
+    + hash::Hash
+{
+    /// Serialize impl for a floating point value.
+    fn serialize(value: T) -> Result<Self, Error>;
+
+    /// Visit the current value.
+    fn visit<'de, V>(&self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>;
+}
+
+// NB: we completely seal the FloatPolicy to prevent external implementations.
+mod private {
+    pub trait Sealed<A> {}
+    impl<T, A> Sealed<A> for T where T: super::FloatRepr<A> {}
+}

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -1,72 +1,76 @@
 #[cfg(feature = "ordered-float")]
-pub use self::ordered_float::{to_key_with_ordered_float, OrderedFloat};
+pub use self::ordered_float::{to_key_with_ordered_float, OrderedFloat, OrderedFloatPolicy};
 use crate::error::Error;
-use serde::{de, ser};
-use std::hash::Hash;
+use serde::de;
 
+mod float_policy;
+mod float_repr;
 #[cfg(feature = "ordered-float")]
 mod ordered_float;
 
-// NB: we completely seal the FloatPolicy to prevent external implementations.
-mod private {
-    pub trait Sealed {}
+pub use self::float_policy::FloatPolicy;
+pub use self::float_repr::FloatRepr;
 
-    impl<T> Sealed for T where T: super::FloatPolicy {}
-}
-
-/// A policy for handling floating point types in a `Key`.
-///
-/// Currently there are two important `FloatPolicy` types: [`RejectFloat`] and
-/// [`OrderedFloat`]. The former will emit errors instead of allowing floats to
-/// be serialized and the latter while serialize them and provide a total order
-/// which does not adhere to the IEEE standard.
-///
-/// [`RejectFloat`]: RejectFloat
-/// [`OrderedFloat`]: OrderedFloat
-pub trait FloatPolicy:
-    self::private::Sealed + Clone + PartialEq + Eq + PartialOrd + Ord + Hash
-{
-    /// Serialize an `f32`, possibly failing.
-    fn serialize_f32(value: f32) -> Result<Self, Error>;
-
-    /// Serialize an `f64`, possibly failing.
-    fn serialize_f64(value: f64) -> Result<Self, Error>;
-
-    /// Serialize some floating point type, possibly failing.
-    fn serialize_float<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer;
-
-    /// Deserialize some other type from this floating point type, possibly failing.
-    fn deserialize_float<'de, V>(&self, visitor: V) -> Result<V::Value, Error>
-    where
-        V: de::Visitor<'de>;
-}
-
-/// A float serialization policy which rejects any attempt to serialize a float with an error.
+/// An uninhabitable type for float policies that cannot produce a value of the
+/// corresponding type. This is used by [RejectFloatPolicy].
 #[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub enum RejectFloat {}
+pub enum NeverFloat {}
 
-impl FloatPolicy for RejectFloat {
-    fn serialize_f32(_: f32) -> Result<Self, Error> {
+impl FloatRepr<f32> for NeverFloat {
+    fn serialize(_: f32) -> Result<Self, Error> {
         Err(Error::UnsupportedType("f32"))
     }
 
-    fn serialize_f64(_: f64) -> Result<Self, Error> {
-        Err(Error::UnsupportedType("f64"))
-    }
-
-    fn serialize_float<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        match *self {}
-    }
-
-    fn deserialize_float<'de, V>(&self, _visitor: V) -> Result<V::Value, Error>
+    fn visit<'de, V>(&self, _: V) -> Result<V::Value, Error>
     where
         V: de::Visitor<'de>,
     {
-        match *self {}
+        Err(Error::UnsupportedType("f32"))
     }
+}
+
+impl FloatRepr<f64> for NeverFloat {
+    fn serialize(_: f64) -> Result<Self, Error> {
+        Err(Error::UnsupportedType("f64"))
+    }
+
+    fn visit<'de, V>(&self, _: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        Err(Error::UnsupportedType("f64"))
+    }
+}
+
+impl serde::Serialize for NeverFloat {
+    fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // Note: type is uninhabitable, so this impl can never be reached.
+        unreachable!()
+    }
+}
+
+/// A float serialization policy which rejects any attempt to serialize a float
+/// with an error. This policy is used by the [to_key] function.
+///
+/// [to_key]: crate::to_key
+///
+/// # Examples
+///
+/// ```rust
+/// use serde_hashkey::{Key, Float, to_key};
+///
+/// # fn main() -> Result<(), serde_hashkey::Error> {
+/// assert!(to_key(&"John Doe").is_ok());
+/// assert!(to_key(&42.42f32).is_err());
+/// # Ok(()) }
+/// ```
+#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct RejectFloatPolicy(());
+
+impl FloatPolicy for RejectFloatPolicy {
+    type F32 = NeverFloat;
+    type F64 = NeverFloat;
 }

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -1,11 +1,18 @@
 #[cfg(feature = "ordered-float")]
-pub use self::ordered_float::OrderedFloat;
+pub use self::ordered_float::{to_key_with_ordered_float, OrderedFloat};
 use crate::error::Error;
 use serde::{de, ser};
 use std::hash::Hash;
 
 #[cfg(feature = "ordered-float")]
 mod ordered_float;
+
+// NB: we completely seal the FloatPolicy to prevent external implementations.
+mod private {
+    pub trait Sealed {}
+
+    impl<T> Sealed for T where T: super::FloatPolicy {}
+}
 
 /// A policy for handling floating point types in a `Key`.
 ///
@@ -16,7 +23,9 @@ mod ordered_float;
 ///
 /// [`RejectFloat`]: RejectFloat
 /// [`OrderedFloat`]: OrderedFloat
-pub trait FloatPolicy: Clone + PartialEq + Eq + PartialOrd + Ord + Hash {
+pub trait FloatPolicy:
+    self::private::Sealed + Clone + PartialEq + Eq + PartialOrd + Ord + Hash
+{
     /// Serialize an `f32`, possibly failing.
     fn serialize_f32(value: f32) -> Result<Self, Error>;
 

--- a/src/float/ordered_float.rs
+++ b/src/float/ordered_float.rs
@@ -83,3 +83,47 @@ impl FloatPolicy for OrderedFloat {
         }
     }
 }
+
+/// Serialize the given value to a [Key], with an [OrderedFloat] float policy.
+///
+/// # Examples
+///
+/// ```rust
+/// use serde_derive::{Deserialize, Serialize};
+/// use serde_hashkey::{from_key, to_key_with_ordered_float, OrderedFloat, Key};
+/// use std::collections::HashMap;
+///
+/// #[derive(Debug, PartialEq, Serialize, Deserialize)]
+/// struct Author {
+///     name: String,
+///     age: f32,
+/// }
+///
+/// #[derive(Debug, PartialEq, Serialize, Deserialize)]
+/// struct Book {
+///     title: String,
+///     author: Author,
+/// }
+///
+/// # fn main() -> serde_hashkey::Result<()> {
+/// let book = Book {
+///     title: String::from("Birds of a feather"),
+///     author: Author {
+///         name: String::from("Noah"),
+///         age: 42.5,
+///     },
+/// };
+///
+/// let key = to_key_with_ordered_float(&book)?;
+/// let book2 = from_key(&key)?;
+///
+/// assert_eq!(book, book2);
+/// # Ok(())
+/// # }
+/// ```
+pub fn to_key_with_ordered_float<T>(value: &T) -> Result<crate::Key<OrderedFloat>, Error>
+where
+    T: ser::Serialize,
+{
+    crate::ser::to_key_with_policy::<T, OrderedFloat>(value)
+}

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,6 +1,9 @@
 //! In-memory value representation for values.
-use crate::float::{FloatPolicy, RejectFloat};
+use crate::float::{FloatPolicy, FloatRepr, RejectFloatPolicy};
+use serde::{de, ser};
+use std::fmt;
 use std::hash::Hash;
+use std::marker;
 use std::mem;
 
 /// An opaque integer.
@@ -28,6 +31,18 @@ pub enum Integer {
     U128(u128),
 }
 
+/// An opaque float derived from a given policy.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Float<F>
+where
+    F: FloatPolicy,
+{
+    /// Variant representing a `f32` float.
+    F32(F::F32),
+    /// Variant representing a `f64` float.
+    F64(F::F64),
+}
+
 /// The central key type, which is an in-memory representation of all supported
 /// serde-serialized values.
 ///
@@ -35,10 +50,38 @@ pub enum Integer {
 /// [from_key], and deserialized from a type implementing [serde::Serialize]
 /// using [to_key]. See the corresponding function for documentation.
 ///
+/// The type parameter `F` corresponds to the [FloatPolicy] in used. It defaults
+/// to [RejectFloatPolicy] which will cause floats to be rejected.
+///
 /// [from_key]: crate::from_key
 /// [to_key]: crate::to_key
+///
+/// # Examples
+///
+/// ```rust
+/// use serde_derive::{Deserialize, Serialize};
+/// use serde_hashkey::{to_key, to_key_with_ordered_float};
+///
+/// #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// struct Author {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// # fn main() -> Result<(), serde_hashkey::Error> {
+/// let key = to_key(&Author {
+///     name: String::from("Jane Doe"),
+///     age: 42,
+/// })?;
+///
+/// // Note: serializing floats will fail under the default policy, but succeed
+/// // under one supporting floats.
+/// assert!(to_key(&42.0f32).is_err());
+/// assert!(to_key_with_ordered_float(&42.0f32).is_ok());
+/// # Ok(()) }
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Key<F = RejectFloat>
+pub enum Key<F = RejectFloatPolicy>
 where
     F: FloatPolicy,
 {
@@ -48,8 +91,8 @@ where
     Bool(bool),
     /// An integer.
     Integer(Integer),
-    /// A floating-point number.
-    Float(F),
+    /// A 32-bit floating-point number.
+    Float(Float<F>),
     /// A byte array.
     Bytes(Vec<u8>),
     /// A string.
@@ -134,12 +177,333 @@ impl_from!(Key::String, String);
 impl_from!(Key::Vec, Vec<Key<F>>);
 impl_from!(Key::Map, Vec<(Key<F>, Key<F>)>);
 
+/// Serialize implementation for a [Key].
+///
+/// This allows keys to be serialized immediately.
+///
+/// # Examples
+///
+/// ```rust
+/// use serde_derive::Serialize;
+/// use serde_hashkey::{Key, OrderedFloatPolicy, OrderedFloat, Float};
+///
+/// #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+/// struct Foo {
+///     key: Key<OrderedFloatPolicy>,
+/// }
+///
+/// # fn main() -> Result<(), serde_json::Error> {
+/// let foo: String = serde_json::to_string(&Foo { key: Key::Float(Float::F64(OrderedFloat(42.42f64))) })?;
+///
+/// assert_eq!(foo, "{\"key\":42.42}");
+/// Ok(())
+/// # }
+/// ```
+impl<F> ser::Serialize for Key<F>
+where
+    F: FloatPolicy,
+{
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        match self {
+            Key::Unit => serializer.serialize_unit(),
+            Key::Integer(Integer::U8(v)) => serializer.serialize_u8(*v),
+            Key::Integer(Integer::U16(v)) => serializer.serialize_u16(*v),
+            Key::Integer(Integer::U32(v)) => serializer.serialize_u32(*v),
+            Key::Integer(Integer::U64(v)) => serializer.serialize_u64(*v),
+            Key::Integer(Integer::U128(v)) => serializer.serialize_u128(*v),
+            Key::Integer(Integer::I8(v)) => serializer.serialize_i8(*v),
+            Key::Integer(Integer::I16(v)) => serializer.serialize_i16(*v),
+            Key::Integer(Integer::I32(v)) => serializer.serialize_i32(*v),
+            Key::Integer(Integer::I64(v)) => serializer.serialize_i64(*v),
+            Key::Integer(Integer::I128(v)) => serializer.serialize_i128(*v),
+            Key::Float(Float::F32(float)) => float.serialize(serializer),
+            Key::Float(Float::F64(float)) => float.serialize(serializer),
+            Key::Bytes(v) => serializer.serialize_bytes(&v),
+            Key::String(v) => serializer.serialize_str(&v),
+            Key::Vec(v) => v.serialize(serializer),
+            Key::Map(m) => {
+                use self::ser::SerializeMap as _;
+
+                let mut map = serializer.serialize_map(Some(m.len()))?;
+
+                for (k, v) in m {
+                    map.serialize_key(k)?;
+                    map.serialize_value(v)?;
+                }
+
+                map.end()
+            }
+            Key::Bool(v) => serializer.serialize_bool(*v),
+        }
+    }
+}
+
+/// Deserialize implementation for a [Key].
+///
+/// This allows keys to be serialized immediately.
+///
+/// # Examples
+///
+/// ```rust
+/// use serde_derive::Deserialize;
+/// use serde_hashkey::{Key, OrderedFloatPolicy};
+///
+/// #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]
+/// struct Foo {
+///     key: Key<OrderedFloatPolicy>,
+/// }
+///
+/// # fn main() -> Result<(), serde_json::Error> {
+/// let foo: Foo = serde_json::from_str("{\"key\": 42.42}")?;
+///
+/// assert!(matches!(foo.key, Key::Float(..)));
+/// Ok(())
+/// # }
+/// ```
+impl<'de, F> de::Deserialize<'de> for Key<F>
+where
+    F: FloatPolicy,
+{
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> Result<Key<F>, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct ValueVisitor<F>(marker::PhantomData<F>)
+        where
+            F: FloatPolicy;
+
+        impl<'de, F> de::Visitor<'de> for ValueVisitor<F>
+        where
+            F: FloatPolicy,
+        {
+            type Value = Key<F>;
+
+            fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt.write_str("any valid key")
+            }
+
+            #[inline]
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                self.visit_string(String::from(value))
+            }
+
+            #[inline]
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Key::String(value))
+            }
+
+            #[inline]
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                self.visit_byte_buf(v.to_owned())
+            }
+
+            #[inline]
+            fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Key::Bytes(v))
+            }
+
+            #[inline]
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(v.into())
+            }
+
+            #[inline]
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(v.into())
+            }
+
+            #[inline]
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(v.into())
+            }
+
+            #[inline]
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(v.into())
+            }
+
+            #[inline]
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(v.into())
+            }
+
+            #[inline]
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(v.into())
+            }
+
+            #[inline]
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(v.into())
+            }
+
+            #[inline]
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(v.into())
+            }
+
+            #[inline]
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(v.into())
+            }
+
+            #[inline]
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(v.into())
+            }
+
+            #[inline]
+            fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Key::Float(Float::F32(
+                    <F::F32 as FloatRepr<f32>>::serialize(v).map_err(E::custom)?,
+                )))
+            }
+
+            #[inline]
+            fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Key::Float(Float::F64(
+                    <F::F64 as FloatRepr<f64>>::serialize(v).map_err(E::custom)?,
+                )))
+            }
+
+            #[inline]
+            fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Key::Bool(v))
+            }
+
+            #[inline]
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                self.visit_unit()
+            }
+
+            #[inline]
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Key::Unit)
+            }
+
+            #[inline]
+            fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::SeqAccess<'de>,
+            {
+                let mut vec = Vec::new();
+
+                while let Some(elem) = visitor.next_element()? {
+                    vec.push(elem);
+                }
+
+                Ok(Key::Vec(vec))
+            }
+
+            #[inline]
+            fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let mut values = Vec::new();
+
+                while let Some((key, value)) = visitor.next_entry()? {
+                    values.insert(key, value);
+                }
+
+                Ok(Key::Map(values))
+            }
+        }
+
+        deserializer.deserialize_any(ValueVisitor::<F>(marker::PhantomData))
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::RejectFloatPolicy;
+
     use super::Key;
 
     #[test]
     fn assert_default() {
         assert_eq!(Key::Unit, Key::default());
+    }
+
+    #[test]
+    fn assert_impls() {
+        assert_eq::<Key<RejectFloatPolicy>>();
+        assert_hash::<Key<RejectFloatPolicy>>();
+        assert_ord::<Key<RejectFloatPolicy>>();
+
+        #[cfg(feature = "ordered-float")]
+        {
+            use crate::OrderedFloatPolicy;
+
+            assert_eq::<Key<OrderedFloatPolicy>>();
+            assert_hash::<Key<OrderedFloatPolicy>>();
+            assert_ord::<Key<OrderedFloatPolicy>>();
+        }
+
+        fn assert_eq<T: std::cmp::Eq>() {}
+        fn assert_hash<T: std::hash::Hash>() {}
+        fn assert_ord<T: std::cmp::Ord>() {}
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -38,7 +38,10 @@ pub enum Integer {
 /// [from_key]: crate::from_key
 /// [to_key]: crate::to_key
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Key<Float: FloatPolicy = RejectFloat> {
+pub enum Key<F = RejectFloat>
+where
+    F: FloatPolicy,
+{
     /// A unit value.
     Unit,
     /// A boolean value.
@@ -46,15 +49,15 @@ pub enum Key<Float: FloatPolicy = RejectFloat> {
     /// An integer.
     Integer(Integer),
     /// A floating-point number.
-    Float(Float),
+    Float(F),
     /// A byte array.
     Bytes(Vec<u8>),
     /// A string.
     String(String),
     /// A vector.
-    Vec(Vec<Key<Float>>),
+    Vec(Vec<Key<F>>),
     /// A map.
-    Map(Vec<(Key<Float>, Key<Float>)>),
+    Map(Vec<(Key<F>, Key<F>)>),
 }
 
 impl Default for Key {
@@ -90,8 +93,11 @@ impl Key {
 
 macro_rules! impl_integer_from {
     ($variant:ident, $for_type:ty) => {
-        impl<Float: FloatPolicy> From<$for_type> for Key<Float> {
-            fn from(v: $for_type) -> Key<Float> {
+        impl<F> From<$for_type> for Key<F>
+        where
+            F: FloatPolicy,
+        {
+            fn from(v: $for_type) -> Key<F> {
                 Key::Integer(Integer::$variant(v))
             }
         }
@@ -100,8 +106,11 @@ macro_rules! impl_integer_from {
 
 macro_rules! impl_from {
     ($variant:path, $for_type:ty) => {
-        impl<Float: FloatPolicy> From<$for_type> for Key<Float> {
-            fn from(v: $for_type) -> Key<Float> {
+        impl<F> From<$for_type> for Key<F>
+        where
+            F: FloatPolicy,
+        {
+            fn from(v: $for_type) -> Key<F> {
                 $variant(v.into())
             }
         }
@@ -122,8 +131,8 @@ impl_integer_from!(U128, u128);
 impl_from!(Key::Bool, bool);
 impl_from!(Key::Bytes, Vec<u8>);
 impl_from!(Key::String, String);
-impl_from!(Key::Vec, Vec<Key<Float>>);
-impl_from!(Key::Map, Vec<(Key<Float>, Key<Float>)>);
+impl_from!(Key::Vec, Vec<Key<F>>);
+impl_from!(Key::Map, Vec<(Key<F>, Key<F>)>);
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,10 +108,10 @@ mod ser;
 pub use crate::de::from_key;
 #[doc(inline)]
 pub use crate::error::{Error, Result};
-pub use crate::float::RejectFloat;
 #[cfg(feature = "ordered-float")]
-pub use crate::float::{to_key_with_ordered_float, OrderedFloat};
+pub use crate::float::{to_key_with_ordered_float, OrderedFloat, OrderedFloatPolicy};
+pub use crate::float::{FloatPolicy, FloatRepr, NeverFloat, RejectFloatPolicy};
 #[doc(inline)]
-pub use crate::key::{Integer, Key};
+pub use crate::key::{Float, Integer, Key};
 #[doc(inline)]
 pub use crate::ser::to_key;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,18 +11,31 @@
 //! Serde-based in-memory key serialization.
 //!
 //! This allows any serde-serializable type to be converted into a value which
-//! implements `PartialEq`, `Eq`, `ParialOrd`, `Ord`, and `Hash`. This can include
-//! floating point types such as `f32` and `f64` depending on the
-//! [FloatPolicy] used with the [Key] type. By
-//! default, attempts to serialize `f32` and `f64` will cause an error; this
-//! is because `f32` and `f64` are neither [totally ordered nor hashable] by default.
-//! To enable the [Key] type to use `f32` and `f64`, parameterize
-//! it with the [OrderedFloat] policy, like so: `Key<OrderedFloat>`.
+//! implements `PartialEq`, `Eq`, `ParialOrd`, `Ord`, and `Hash`.
 //!
 //! [Key] is useful because it allows for a form of type-erasure. Let's say you
 //! want to build a generic in-memory key-value store where you want to store
 //! arbitrary serde-serializable keys. This is typical for things like caches or
 //! dependency injection frameworks.
+//!
+//! ## Float policies
+//!
+//! By default, [Key] can't include floating point types such as `f32` and
+//! `f64`. Neither of these are [totally ordered nor hashable].
+//!
+//! To enable the [Key] type to use `f32` and `f64` it can be constructed with a
+//! specific float policy.
+//!
+//! Available float policies are:
+//! * [RejectFloat] - the default behavior when using [to_key].
+//! * [OrderedFloat] - the behavior when using [to_key_with_ordered_float]. The
+//!   `ordered-float` feature must be enabled to use this. The behavior is
+//!   derived from the [`ordered-float` crate].
+//!
+//! ## Features
+//!
+//! * `ordered-float` - Enables serializing floating point numbers through
+//!   behavior derived from the [`ordered-float` crate]
 //!
 //! ## Examples
 //!
@@ -77,9 +90,11 @@
 //!
 //! [totally ordered nor hashable]: https://internals.rust-lang.org/t/f32-f64-should-implement-hash/5436
 //! [Key]: https://docs.rs/serde-hashkey/0/serde_hashkey/enum.Key.html
-//! [FloatPolicy]: https://docs.rs/serde-hashkey/0/serde_hashkey/trait.FloatPolicy.html
+//! [to_key]: https://docs.rs/serde-hashkey/0/serde_hashkey/fn.to_key.html
 //! [RejectFloat]: https://docs.rs/serde-hashkey/0/serde_hashkey/enum.RejectFloat.html
 //! [OrderedFloat]: https://docs.rs/serde-hashkey/0/serde_hashkey/enum.OrderedFloat.html
+//! [to_key_with_ordered_float]: https://docs.rs/serde-hashkey/0/serde_hashkey/fn.to_key_with_ordered_float.html
+//! [`ordered-float` crate]: https://docs.rs/ordered-float/2/ordered_float/
 
 #![deny(missing_docs)]
 
@@ -90,13 +105,13 @@ mod key;
 mod ser;
 
 #[doc(inline)]
-pub use crate::de::{from_key, from_key_with_policy};
+pub use crate::de::from_key;
 #[doc(inline)]
 pub use crate::error::{Error, Result};
-#[cfg(feature = "ordered-float")]
-pub use crate::float::OrderedFloat;
 pub use crate::float::RejectFloat;
+#[cfg(feature = "ordered-float")]
+pub use crate::float::{to_key_with_ordered_float, OrderedFloat};
 #[doc(inline)]
 pub use crate::key::{Integer, Key};
 #[doc(inline)]
-pub use crate::ser::{to_key, to_key_with_policy};
+pub use crate::ser::to_key;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -59,7 +59,10 @@ where
     value.serialize(Serializer(PhantomData))
 }
 
-impl<Float: FloatPolicy> ser::Serialize for Key<Float> {
+impl<F> ser::Serialize for Key<F>
+where
+    F: FloatPolicy,
+{
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -98,107 +101,112 @@ impl<Float: FloatPolicy> ser::Serialize for Key<Float> {
     }
 }
 
-struct Serializer<Float: FloatPolicy>(PhantomData<Float>);
+struct Serializer<F>(PhantomData<F>)
+where
+    F: FloatPolicy;
 
-impl<Float: FloatPolicy> ser::Serializer for Serializer<Float> {
-    type Ok = Key<Float>;
+impl<F> ser::Serializer for Serializer<F>
+where
+    F: FloatPolicy,
+{
+    type Ok = Key<F>;
     type Error = Error;
 
-    type SerializeSeq = SerializeVec<Float>;
-    type SerializeTuple = SerializeVec<Float>;
-    type SerializeTupleStruct = SerializeVec<Float>;
-    type SerializeTupleVariant = SerializeTupleVariant<Float>;
-    type SerializeMap = SerializeMap<Float>;
-    type SerializeStruct = SerializeMap<Float>;
-    type SerializeStructVariant = SerializeStructVariant<Float>;
+    type SerializeSeq = SerializeVec<F>;
+    type SerializeTuple = SerializeVec<F>;
+    type SerializeTupleStruct = SerializeVec<F>;
+    type SerializeTupleVariant = SerializeTupleVariant<F>;
+    type SerializeMap = SerializeMap<F>;
+    type SerializeStruct = SerializeMap<F>;
+    type SerializeStructVariant = SerializeStructVariant<F>;
 
     #[inline]
-    fn serialize_bool(self, value: bool) -> Result<Key<Float>, Error> {
+    fn serialize_bool(self, value: bool) -> Result<Key<F>, Error> {
         Ok(Key::Bool(value))
     }
 
     #[inline]
-    fn serialize_i8(self, value: i8) -> Result<Key<Float>, Error> {
+    fn serialize_i8(self, value: i8) -> Result<Key<F>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_i16(self, value: i16) -> Result<Key<Float>, Error> {
+    fn serialize_i16(self, value: i16) -> Result<Key<F>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_i32(self, value: i32) -> Result<Key<Float>, Error> {
+    fn serialize_i32(self, value: i32) -> Result<Key<F>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_i64(self, value: i64) -> Result<Key<Float>, Error> {
+    fn serialize_i64(self, value: i64) -> Result<Key<F>, Error> {
         Ok(value.into())
     }
 
-    fn serialize_i128(self, value: i128) -> Result<Key<Float>, Error> {
-        Ok(value.into())
-    }
-
-    #[inline]
-    fn serialize_u8(self, value: u8) -> Result<Key<Float>, Error> {
+    fn serialize_i128(self, value: i128) -> Result<Key<F>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_u16(self, value: u16) -> Result<Key<Float>, Error> {
+    fn serialize_u8(self, value: u8) -> Result<Key<F>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_u32(self, value: u32) -> Result<Key<Float>, Error> {
+    fn serialize_u16(self, value: u16) -> Result<Key<F>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_u64(self, value: u64) -> Result<Key<Float>, Error> {
+    fn serialize_u32(self, value: u32) -> Result<Key<F>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_u128(self, value: u128) -> Result<Key<Float>, Error> {
+    fn serialize_u64(self, value: u64) -> Result<Key<F>, Error> {
         Ok(value.into())
     }
 
     #[inline]
-    fn serialize_f32(self, value: f32) -> Result<Key<Float>, Error> {
-        Float::serialize_f32(value).map(Key::Float)
+    fn serialize_u128(self, value: u128) -> Result<Key<F>, Error> {
+        Ok(value.into())
     }
 
     #[inline]
-    fn serialize_f64(self, value: f64) -> Result<Key<Float>, Error> {
-        Float::serialize_f64(value).map(Key::Float)
+    fn serialize_f32(self, value: f32) -> Result<Key<F>, Error> {
+        Ok(Key::Float(F::serialize_f32(value)?))
     }
 
     #[inline]
-    fn serialize_char(self, value: char) -> Result<Key<Float>, Error> {
+    fn serialize_f64(self, value: f64) -> Result<Key<F>, Error> {
+        Ok(Key::Float(F::serialize_f64(value)?))
+    }
+
+    #[inline]
+    fn serialize_char(self, value: char) -> Result<Key<F>, Error> {
         let mut s = String::new();
         s.push(value);
         self.serialize_str(&s)
     }
 
     #[inline]
-    fn serialize_str(self, value: &str) -> Result<Key<Float>, Error> {
+    fn serialize_str(self, value: &str) -> Result<Key<F>, Error> {
         Ok(Key::String(value.to_owned()))
     }
 
-    fn serialize_bytes(self, value: &[u8]) -> Result<Key<Float>, Error> {
+    fn serialize_bytes(self, value: &[u8]) -> Result<Key<F>, Error> {
         Ok(Key::Bytes(value.to_vec()))
     }
 
     #[inline]
-    fn serialize_unit(self) -> Result<Key<Float>, Error> {
+    fn serialize_unit(self) -> Result<Key<F>, Error> {
         Ok(Key::Unit)
     }
 
     #[inline]
-    fn serialize_unit_struct(self, _name: &'static str) -> Result<Key<Float>, Error> {
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Key<F>, Error> {
         self.serialize_unit()
     }
 
@@ -208,7 +216,7 @@ impl<Float: FloatPolicy> ser::Serializer for Serializer<Float> {
         _name: &'static str,
         _variant_index: u32,
         variant: &'static str,
-    ) -> Result<Key<Float>, Error> {
+    ) -> Result<Key<F>, Error> {
         self.serialize_str(variant)
     }
 
@@ -217,7 +225,7 @@ impl<Float: FloatPolicy> ser::Serializer for Serializer<Float> {
         self,
         _name: &'static str,
         value: &T,
-    ) -> Result<Key<Float>, Error>
+    ) -> Result<Key<F>, Error>
     where
         T: ser::Serialize,
     {
@@ -230,7 +238,7 @@ impl<Float: FloatPolicy> ser::Serializer for Serializer<Float> {
         _variant_index: u32,
         variant: &'static str,
         value: &T,
-    ) -> Result<Key<Float>, Error>
+    ) -> Result<Key<F>, Error>
     where
         T: ser::Serialize,
     {
@@ -239,12 +247,12 @@ impl<Float: FloatPolicy> ser::Serializer for Serializer<Float> {
     }
 
     #[inline]
-    fn serialize_none(self) -> Result<Key<Float>, Error> {
+    fn serialize_none(self) -> Result<Key<F>, Error> {
         self.serialize_unit()
     }
 
     #[inline]
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Key<Float>, Error>
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Key<F>, Error>
     where
         T: ser::Serialize,
     {
@@ -316,27 +324,42 @@ impl<Float: FloatPolicy> ser::Serializer for Serializer<Float> {
     }
 }
 
-pub struct SerializeVec<Float: FloatPolicy> {
-    vec: Vec<Key<Float>>,
+pub struct SerializeVec<F>
+where
+    F: FloatPolicy,
+{
+    vec: Vec<Key<F>>,
 }
 
-pub struct SerializeTupleVariant<Float: FloatPolicy> {
+pub struct SerializeTupleVariant<F>
+where
+    F: FloatPolicy,
+{
     name: String,
-    vec: Vec<Key<Float>>,
+    vec: Vec<Key<F>>,
 }
 
-pub struct SerializeMap<Float: FloatPolicy> {
-    map: Vec<(Key<Float>, Key<Float>)>,
-    next_key: Option<Key<Float>>,
+pub struct SerializeMap<F>
+where
+    F: FloatPolicy,
+{
+    map: Vec<(Key<F>, Key<F>)>,
+    next_key: Option<Key<F>>,
 }
 
-pub struct SerializeStructVariant<Float: FloatPolicy> {
+pub struct SerializeStructVariant<F>
+where
+    F: FloatPolicy,
+{
     name: String,
-    map: Vec<(Key<Float>, Key<Float>)>,
+    map: Vec<(Key<F>, Key<F>)>,
 }
 
-impl<Float: FloatPolicy> ser::SerializeSeq for SerializeVec<Float> {
-    type Ok = Key<Float>;
+impl<F> ser::SerializeSeq for SerializeVec<F>
+where
+    F: FloatPolicy,
+{
+    type Ok = Key<F>;
     type Error = Error;
 
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
@@ -347,13 +370,16 @@ impl<Float: FloatPolicy> ser::SerializeSeq for SerializeVec<Float> {
         Ok(())
     }
 
-    fn end(self) -> Result<Key<Float>, Error> {
+    fn end(self) -> Result<Key<F>, Error> {
         Ok(Key::Vec(self.vec))
     }
 }
 
-impl<Float: FloatPolicy> ser::SerializeTuple for SerializeVec<Float> {
-    type Ok = Key<Float>;
+impl<F> ser::SerializeTuple for SerializeVec<F>
+where
+    F: FloatPolicy,
+{
+    type Ok = Key<F>;
     type Error = Error;
 
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
@@ -363,13 +389,16 @@ impl<Float: FloatPolicy> ser::SerializeTuple for SerializeVec<Float> {
         ser::SerializeSeq::serialize_element(self, value)
     }
 
-    fn end(self) -> Result<Key<Float>, Error> {
+    fn end(self) -> Result<Key<F>, Error> {
         ser::SerializeSeq::end(self)
     }
 }
 
-impl<Float: FloatPolicy> ser::SerializeTupleStruct for SerializeVec<Float> {
-    type Ok = Key<Float>;
+impl<F> ser::SerializeTupleStruct for SerializeVec<F>
+where
+    F: FloatPolicy,
+{
+    type Ok = Key<F>;
     type Error = Error;
 
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
@@ -379,13 +408,16 @@ impl<Float: FloatPolicy> ser::SerializeTupleStruct for SerializeVec<Float> {
         ser::SerializeSeq::serialize_element(self, value)
     }
 
-    fn end(self) -> Result<Key<Float>, Error> {
+    fn end(self) -> Result<Key<F>, Error> {
         ser::SerializeSeq::end(self)
     }
 }
 
-impl<Float: FloatPolicy> ser::SerializeTupleVariant for SerializeTupleVariant<Float> {
-    type Ok = Key<Float>;
+impl<F> ser::SerializeTupleVariant for SerializeTupleVariant<F>
+where
+    F: FloatPolicy,
+{
+    type Ok = Key<F>;
     type Error = Error;
 
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
@@ -396,14 +428,17 @@ impl<Float: FloatPolicy> ser::SerializeTupleVariant for SerializeTupleVariant<Fl
         Ok(())
     }
 
-    fn end(self) -> Result<Key<Float>, Error> {
+    fn end(self) -> Result<Key<F>, Error> {
         let value = (Key::from(self.name), Key::Vec(self.vec));
         Ok(Key::Map(vec![value]))
     }
 }
 
-impl<Float: FloatPolicy> ser::SerializeMap for SerializeMap<Float> {
-    type Ok = Key<Float>;
+impl<F> ser::SerializeMap for SerializeMap<F>
+where
+    F: FloatPolicy,
+{
+    type Ok = Key<F>;
     type Error = Error;
 
     fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Error>
@@ -427,13 +462,16 @@ impl<Float: FloatPolicy> ser::SerializeMap for SerializeMap<Float> {
         Ok(())
     }
 
-    fn end(self) -> Result<Key<Float>, Error> {
+    fn end(self) -> Result<Key<F>, Error> {
         Ok(Key::Map(self.map))
     }
 }
 
-impl<Float: FloatPolicy> ser::SerializeStruct for SerializeMap<Float> {
-    type Ok = Key<Float>;
+impl<F> ser::SerializeStruct for SerializeMap<F>
+where
+    F: FloatPolicy,
+{
+    type Ok = Key<F>;
     type Error = Error;
 
     fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
@@ -444,13 +482,16 @@ impl<Float: FloatPolicy> ser::SerializeStruct for SerializeMap<Float> {
         ser::SerializeMap::serialize_value(self, value)
     }
 
-    fn end(self) -> Result<Key<Float>, Error> {
+    fn end(self) -> Result<Key<F>, Error> {
         ser::SerializeMap::end(self)
     }
 }
 
-impl<Float: FloatPolicy> ser::SerializeStructVariant for SerializeStructVariant<Float> {
-    type Ok = Key<Float>;
+impl<F> ser::SerializeStructVariant for SerializeStructVariant<F>
+where
+    F: FloatPolicy,
+{
+    type Ok = Key<F>;
     type Error = Error;
 
     fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
@@ -462,7 +503,7 @@ impl<Float: FloatPolicy> ser::SerializeStructVariant for SerializeStructVariant<
         Ok(())
     }
 
-    fn end(self) -> Result<Key<Float>, Error> {
+    fn end(self) -> Result<Key<F>, Error> {
         let value = (Key::from(self.name), Key::Map(self.map));
         Ok(Key::Map(vec![value]))
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -44,54 +44,17 @@ use crate::key::{Integer, Key};
 /// # Ok(())
 /// # }
 /// ```
-pub fn to_key<T>(value: &T) -> Result<Key, Error>
+pub fn to_key<T>(value: &T) -> Result<Key<crate::RejectFloat>, Error>
 where
     T: ser::Serialize,
 {
-    value.serialize(Serializer(PhantomData))
+    to_key_with_policy::<T, crate::RejectFloat>(value)
 }
 
-/// Serialize the given value to a [Key], with a non-default [`FloatPolicy`](key::FloatPolicy).
-///
-/// # Examples
-///
-/// ```rust
-/// use serde_derive::{Deserialize, Serialize};
-/// use serde_hashkey::{from_key_with_policy, to_key_with_policy, OrderedFloat, Key};
-/// use std::collections::HashMap;
-///
-/// #[derive(Debug, PartialEq, Serialize, Deserialize)]
-/// struct Author {
-///     name: String,
-///     age: f32,
-/// }
-///
-/// #[derive(Debug, PartialEq, Serialize, Deserialize)]
-/// struct Book {
-///     title: String,
-///     author: Author,
-/// }
-///
-/// # fn main() -> serde_hashkey::Result<()> {
-/// let book = Book {
-///     title: String::from("Birds of a feather"),
-///     author: Author {
-///         name: String::from("Noah"),
-///         age: 42.5,
-///     },
-/// };
-///
-/// let key = to_key_with_policy::<OrderedFloat, _>(&book)?;
-/// let book2 = from_key_with_policy::<OrderedFloat, _>(&key)?;
-///
-/// assert_eq!(book, book2);
-/// # Ok(())
-/// # }
-/// ```
-pub fn to_key_with_policy<Float, T>(value: &T) -> Result<Key<Float>, Error>
+pub(crate) fn to_key_with_policy<T, F>(value: &T) -> Result<Key<F>, Error>
 where
-    Float: FloatPolicy,
     T: ser::Serialize,
+    F: FloatPolicy,
 {
     value.serialize(Serializer(PhantomData))
 }

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -2,7 +2,7 @@
 
 use serde_derive::{Deserialize, Serialize};
 use serde_hashkey::{
-    from_key, to_key, to_key_with_ordered_float, Error, Integer, Key, OrderedFloat,
+    from_key, to_key, to_key_with_ordered_float, Error, Float, Integer, Key, OrderedFloat,
 };
 use std::collections::BTreeMap;
 
@@ -96,10 +96,10 @@ fn deny_floats_by_default() {
     assert_eq!(to_key(&0f64), Err(Error::UnsupportedType("f64")));
     assert_eq!(
         to_key_with_ordered_float(&0f32),
-        Ok(Key::Float(OrderedFloat::F32(0f32)))
+        Ok(Key::Float(Float::F32(OrderedFloat(0f32))))
     );
     assert_eq!(
         to_key_with_ordered_float(&0f64),
-        Ok(Key::Float(OrderedFloat::F64(0f64)))
+        Ok(Key::Float(Float::F64(OrderedFloat(0f64))))
     );
 }

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "ordered-float")]
 
 use serde_derive::{Deserialize, Serialize};
-use serde_hashkey::{from_key, to_key, to_key_with_policy, Error, Integer, Key, OrderedFloat};
+use serde_hashkey::{
+    from_key, to_key, to_key_with_ordered_float, Error, Integer, Key, OrderedFloat,
+};
 use std::collections::BTreeMap;
 
 #[test]
@@ -41,11 +43,8 @@ fn test_enum() -> Result<(), Error> {
         other => panic!("unexpected: {:?}", other),
     }
 
-    assert_eq!(foo, from_key::<Foo>(&value)?);
-    assert_eq!(
-        Foo::Operation3,
-        from_key::<Foo>(&to_key(&Foo::Operation3)?)?
-    );
+    assert_eq!(foo, from_key(&value)?);
+    assert_eq!(Foo::Operation3, from_key(&to_key(&Foo::Operation3)?)?);
     return Ok(());
 
     #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -96,11 +95,11 @@ fn deny_floats_by_default() {
     assert_eq!(to_key(&0f32), Err(Error::UnsupportedType("f32")));
     assert_eq!(to_key(&0f64), Err(Error::UnsupportedType("f64")));
     assert_eq!(
-        to_key_with_policy::<OrderedFloat, _>(&0f32),
+        to_key_with_ordered_float(&0f32),
         Ok(Key::Float(OrderedFloat::F32(0f32)))
     );
     assert_eq!(
-        to_key_with_policy::<OrderedFloat, _>(&0f64),
+        to_key_with_ordered_float(&0f64),
         Ok(Key::Float(OrderedFloat::F64(0f64)))
     );
 }


### PR DESCRIPTION
Modifies the float policy to use associated types.

I experimented with it, and I'm generally happier with the outcome:
* There's a clear separation between a policy (how to deal with floats) and the representation of the floats themselves.
* The kind of float a key has been serialized to can be opaquely represented with a separate generic `Float` enum that can be matched against.
* Cleaner forwarding implementation for the `OrderedFloat<T>` wrapper type. Other libraries providing float wrappers have a similar approach, either by using a wrapper over the float or by having one type representing each value (`f32` or `f64`).