### PR TITLE
Update ordered-float dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ edition = "2018"
 
 [features]
 default = []
-ordered-float = ["ordered-float2", "num-traits02"]
+ordered-float = ["ordered-float3", "num-traits02"]
 
 [dependencies]
 serde = "1.0.117"
-ordered-float2 = { package = "ordered-float", version = "2.0.0", optional = true }
+ordered-float3 = { package = "ordered-float", version = "3.0.0", optional = true }
 num-traits02 = { package = "num-traits", version = "0.2.1", optional = true }
 
 [dev-dependencies]

--- a/src/float/ordered_float.rs
+++ b/src/float/ordered_float.rs
@@ -2,7 +2,7 @@ use crate::error::Error;
 use crate::float::{FloatPolicy, FloatRepr};
 use crate::key::Key;
 use num_traits02 as nt02;
-use ordered_float2 as of2;
+use ordered_float3 as of3;
 use serde::{de, ser};
 use std::cmp;
 use std::fmt;
@@ -65,7 +65,7 @@ where
     T: nt02::Float,
 {
     fn eq(&self, other: &Self) -> bool {
-        of2::OrderedFloat(self.0) == of2::OrderedFloat(other.0)
+        of3::OrderedFloat(self.0) == of3::OrderedFloat(other.0)
     }
 }
 
@@ -76,7 +76,7 @@ where
     T: nt02::Float,
 {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(of2::OrderedFloat(self.0).cmp(&of2::OrderedFloat(other.0)))
+        Some(of3::OrderedFloat(self.0).cmp(&of3::OrderedFloat(other.0)))
     }
 }
 
@@ -85,7 +85,7 @@ where
     T: nt02::Float,
 {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        of2::OrderedFloat(self.0).cmp(&of2::OrderedFloat(other.0))
+        of3::OrderedFloat(self.0).cmp(&of3::OrderedFloat(other.0))
     }
 }
 
@@ -94,7 +94,7 @@ where
     T: nt02::Float,
 {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        of2::OrderedFloat(self.0).hash(state)
+        of3::OrderedFloat(self.0).hash(state)
     }
 }
 


### PR DESCRIPTION
Hey there, thanks for serde-hashkey!

`ordered-float` released [version 3.0.0](https://github.com/reem/rust-ordered-float/releases/tag/v3.0.0) so this PR just bumps up the dependency. It appears nothing breaks `serde-hashkey`.