### PR TITLE
Fix deserialization of map types into `Key`

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -471,7 +471,7 @@ where
                     .unwrap_or_default();
 
                 while let Some((key, value)) = visitor.next_entry()? {
-                    map.insert(key, value);
+                    map.push((key, value));
                 }
 
                 Ok(Key::Map(map.into()))


### PR DESCRIPTION
It is surprising that the current implementation works at all, but type inference is cool I guess. `key` is inferred to be a `usize` so that it matches the first input to `Vec::insert`. `value` is then inferred to be `(Key<F>, Key<F>)`.

Anyway, this fixes it so that it does the expected thing and allows you to deserialize map types into `Key`.