### PR TITLE
Make `ordered-float` optional again

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,8 +133,9 @@ pub use crate::error::{Error, Result};
 
 cfg_ordered_float! {
     pub use crate::float::{to_key_with_ordered_float, OrderedFloat, OrderedFloatPolicy};
-    pub use crate::float::{FloatPolicy, FloatRepr, NeverFloat, RejectFloatPolicy};
 }
+
+pub use crate::float::{FloatPolicy, FloatRepr, NeverFloat, RejectFloatPolicy};
 
 #[doc(inline)]
 pub use crate::key::{Float, Integer, Key};


### PR DESCRIPTION
passing `pub use crate::float::{FloatPolicy, FloatRepr, NeverFloat, RejectFloatPolicy};` into `cfg_ordered_float` macro is causing `FloatPolicy, FloatRepr, NeverFloat, RejectFloatPolicy` to not be exported, breaking compilation when `ordered-float` is not enabled.

fixes #7
